### PR TITLE
add binary installation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,3 +5,4 @@ target_link_libraries(Sim3D-v3.2 milotti_mts ${myLibs})
 
 install(DIRECTORY . DESTINATION milotti_mts/include FILES_MATCHING PATTERN "*.h")
 install(TARGETS milotti_mts LIBRARY DESTINATION milotti_mts/lib)
+install(TARGETS Sim3D-v3.2 DESTINATION milotti_mts/bin)


### PR DESCRIPTION
This is needed to execute the code without tumorcode. Compiles and runs on my Ubuntu 16.04 maschine as well.